### PR TITLE
ARM64 Compatibility for Docker Image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,9 @@
-FROM alpine:3.20.3
+FROM alpine:3.20.3 AS build
 
 # installation settings
 ARG TL_MIRROR="https://texlive.info/CTAN/systems/texlive/tlnet"
 
-RUN apk add --no-cache perl curl fontconfig libgcc gnupg && \
+RUN apk add --no-cache perl curl fontconfig libgcc gnupg xz && \
     mkdir "/tmp/texlive" && cd "/tmp/texlive" && \
     wget "$TL_MIRROR/install-tl-unx.tar.gz" && \
     tar xzvf ./install-tl-unx.tar.gz && \
@@ -18,12 +18,31 @@ RUN apk add --no-cache perl curl fontconfig libgcc gnupg && \
         echo "TEXMFSYSVAR /opt/texlive/texmf-var" && \
         echo "TEXMFHOME ~/.texmf" \
     ) > "/tmp/texlive.profile" && \
-    "./install-tl-"*"/install-tl" --location "$TL_MIRROR" -profile "/tmp/texlive.profile" && \
-    rm -vf "/opt/texlive/install-tl" && \
-    rm -vf "/opt/texlive/install-tl.log" && \
-    rm -vrf /tmp/*
+    set -eux; cd "/tmp/texlive" && arch=$(uname -m); \
+	case $arch in \
+		x86_64) ARCHITECTURE='amd64' ;; \
+		aarch64) ARCHITECTURE='arm64' ;; \
+		*) echo >&2 "error: unsupported architecture ($arch)"; exit 1 ;;\
+	esac; \
+    echo "Architecture: $ARCHITECTURE"; \
+    if [ "$ARCHITECTURE" = "amd64" ]; then \
+      "./install-tl-"*"/install-tl" --location "$TL_MIRROR" -profile "/tmp/texlive.profile" && \
+      ln -s /opt/texlive/bin/x86_64-linuxmusl /opt/texlive/bin/current; \
+    fi;  \
+    if [ "$ARCHITECTURE" = "arm64" ]; then \
+      wget https://ftp.math.utah.edu/pub/texlive-utah/bin/aarch64-alpine319.tar.xz && \
+      tar xvf aarch64-alpine319.tar.xz && \
+      "./install-tl-"*"/install-tl" --location "$TL_MIRROR" -profile "/tmp/texlive.profile" --custom-bin=/tmp/texlive/aarch64-alpine319 && \
+      ln -s /opt/texlive/bin/custom /opt/texlive/bin/current; \
+    fi;
 
-ENV PATH="${PATH}:/opt/texlive/bin/x86_64-linuxmusl"
+FROM alpine:3.20.3 AS final
+
+RUN apk add --no-cache perl fontconfig curl gnupg xz
+
+COPY --from=build /opt/texlive /opt/texlive
+
+ENV PATH="${PATH}:/opt/texlive/bin/current"
 
 ARG TL_SCHEME_BASIC="y"
 RUN if [ "$TL_SCHEME_BASIC" = "y" ]; then tlmgr install scheme-basic; fi


### PR DESCRIPTION
Hi @kjarosh,

Thank you for this great project! I’ve made the necessary adjustments to the Dockerfile to add compatibility with the ARM64 architecture, as discussed in issue #13.

### Changes:
- The Dockerfile now includes architecture detection, allowing the image to be built and used on ARM64 systems, such as Apple Silicon Macs.
- For ARM64, TeXLive is installed with a [custom bin](https://tug.org/texlive/custom-bin.html) from [here](https://ftp.math.utah.edu/pub/texlive-utah/bin/).
- The bin path is dynamically linked to either the x86_64 or aarch64 installation, depending on the detected architecture.
- The container build is split into 2 steps, as the image became bloated (the ARM image is still significantly larger than the x86 variant).

This implementation allows the image to work without needing Rosetta 2 emulation on ARM Macs, resolving the platform mismatch issue noted in the original report.

I hope this helps improve the flexibility of the image for users on different architectures. Let me know if you have any feedback or suggestions.

Best regards,  
Boris